### PR TITLE
loading mesh data in mesh.py

### DIFF
--- a/bemio/mesh_utilities/mesh.py
+++ b/bemio/mesh_utilities/mesh.py
@@ -461,7 +461,7 @@ class PanelMesh(object):
 
         # Create a mapper and load VTP data into the mapper
         mapper=vtk.vtkPolyDataMapper()
-        mapper.SetInputData(self.vtp_mesh)
+        mapper.SetInput(self.vtp_mesh)
 
         # Create an actor that contains the data in the mapper
         actor=vtk.vtkActor()

--- a/bemio/mesh_utilities/mesh.py
+++ b/bemio/mesh_utilities/mesh.py
@@ -636,7 +636,7 @@ class PanelMesh(object):
 
         writer = vtk.vtkXMLPolyDataWriter()
         writer.SetFileName(self.files['vtp'])
-        writer.SetInputData(self.vtp_mesh)
+        writer.SetInput(self.vtp_mesh)
         writer.SetDataModeToAscii()
         writer.Write()
 


### PR DESCRIPTION
Looks like the vtk method for loading data is `SetInput` (not `SetInputData`). Maybe this is a version issue (or just a simple mistake)?