### PR TITLE
Python 3 compatibility

### DIFF
--- a/bemio/__init__.py
+++ b/bemio/__init__.py
@@ -1,1 +1,1 @@
-from __version__ import base, full
+from .__version__ import base, full

--- a/bemio/__init__.py
+++ b/bemio/__init__.py
@@ -1,1 +1,2 @@
+from __future__ import absolute_import
 from .__version__ import base, full

--- a/bemio/data_structures/bem.py
+++ b/bemio/data_structures/bem.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import division
+
 
 import numpy as np
 
@@ -266,9 +266,9 @@ class HydrodynamicData(object):
         count = 1
         for t_ind, t in enumerate(self.ex.irf.t):
 
-          for i in xrange(self.ex.mag.shape[0]):
+          for i in range(self.ex.mag.shape[0]):
 
-            for j in xrange(self.ex.mag.shape[1]):
+            for j in range(self.ex.mag.shape[1]):
               tmp = ex_re_interp[i, j, :] * np.cos(self.ex.irf.w * t) - ex_im_interp[i, j, :] * np.sin(self.ex.irf.w * t)
               tmp *= 1. / np.pi
               self.ex.irf.f[i, j, t_ind] = np.trapz(y=tmp, x=self.ex.irf.w)
@@ -353,9 +353,9 @@ class HydrodynamicData(object):
         count = 1
         for t_ind, t in enumerate(self.rd.irf.t):
 
-            for i in xrange(self.rd.all.shape[0]):
+            for i in range(self.rd.all.shape[0]):
 
-                for j in xrange(self.rd.all.shape[1]):
+                for j in range(self.rd.all.shape[1]):
               # Radiation damping calculation method
                     tmpL = 2. / np.pi * rd_interp[i, j, :] * np.sin(self.rd.irf.w * t)
                     tmpK = 2. / np.pi * rd_interp[i, j, :] * np.cos(self.rd.irf.w * t)
@@ -426,9 +426,9 @@ class HydrodynamicData(object):
 
         pbar = ProgressBar(widgets=['Radiation damping state space realization for ' + self.name + ':', Percentage(), Bar()], maxval=self.am.inf.shape[0] * self.am.inf.shape[1]).start()
         count = 0
-        for i in xrange(self.am.inf.shape[0]):
+        for i in range(self.am.inf.shape[0]):
 
-          for j in xrange(self.am.inf.shape[1]):
+          for j in range(self.am.inf.shape[1]):
 
             r2bt = np.linalg.norm(
                 self.rd.irf.K[i, j, :] - self.rd.irf.K.mean(axis=2)[i, j])
@@ -472,7 +472,7 @@ class HydrodynamicData(object):
                 # D - T/2C (2/T(I + A)^{-1})B  = D - C(I + A)^{-1})B
                 dc = d + CoeC * np.dot(np.dot(c, iidd), b)
 
-                for jj in xrange(self.rd.irf.t.size):
+                for jj in range(self.rd.irf.t.size):
 
                   # Calculate impulse response function from state space
                   # approximation
@@ -549,11 +549,11 @@ class HydrodynamicData(object):
             self.scale = scale
 
         if self.scale is True and self.scaled is False:
-          print '\tScaling hydro coefficients for body ' + self.name + ' by rho, g, and w...'
+          print('\tScaling hydro coefficients for body ' + self.name + ' by rho, g, and w...')
           try:
               self.k *= self.rho * self.g
           except:
-              print '\t\tSpring stiffness not scaled'
+              print('\t\tSpring stiffness not scaled')
 
           self.am.all *= self.rho
           self.am.inf *= self.rho
@@ -575,18 +575,18 @@ class HydrodynamicData(object):
               self.ex.fk.im *= self.rho * self.g
 
 
-          for j in xrange(self.rd.all.shape[2]):
+          for j in range(self.rd.all.shape[2]):
 
             self.rd.all[:, :, j] = self.rd.all[:, :, j] * self.rho * self.w[j]
 
           self.scaled = True
 
         elif self.scale is False and self.scaled is True:
-          print '\tUn-scaling hydro coefficients for body ' + self.name + ' by rho, g, and w...'
+          print('\tUn-scaling hydro coefficients for body ' + self.name + ' by rho, g, and w...')
           try:
               self.k /= (self.rho * self.g)
           except:
-              print '\t\tSpring stiffness not un-scaled'
+              print('\t\tSpring stiffness not un-scaled')
           self.am.all /= self.rho
           self.am.inf /= self.rho
           if hasattr(self.am,'zero') is True:
@@ -606,7 +606,7 @@ class HydrodynamicData(object):
               self.ex.fk.re /= (self.rho * self.g)
               self.ex.fk.im /= (self.rho * self.g)
 
-          for j in xrange(self.rd.all.shape[2]):
+          for j in range(self.rd.all.shape[2]):
 
             self.rd.all[:, :, j] = self.rd.all[:, :, j] / (self.rho * self.w[j])
 
@@ -630,9 +630,9 @@ def _interpolate_for_irf(w_orig, w_interp, mat_in):
 
     w_tmp = w_orig
 
-  for i in xrange(mat_in.shape[0]):
+  for i in range(mat_in.shape[0]):
 
-    for j in xrange(mat_in.shape[1]):
+    for j in range(mat_in.shape[1]):
 
       if flip is True:
 

--- a/bemio/data_structures/bem.py
+++ b/bemio/data_structures/bem.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from __future__ import division
 import numpy as np
 
 import os

--- a/bemio/data_structures/wave_excitation.py
+++ b/bemio/data_structures/wave_excitation.py
@@ -74,7 +74,7 @@ class WaveExcitationConvolution(object):
         irf_interp = interpolate.interp1d(x=self.irf.t, y=self.irf.f, bounds_error=False, fill_value=0.)
 
         # Interpolate the IRF to the dt as the wave elevation data
-        irf = irf_interp(np.linspace(self.irf.t.min(),self.irf.t.max(),(self.irf.t.max()-self.irf.t.min())/self.wave_elevation.dt+1))
+        irf = irf_interp(np.arange(self.irf.t.min(),self.irf.t.max(),(self.irf.t.max()-self.irf.t.min())/self.wave_elevation.dt+1))
 
         # Assume that the IRF dt is used unless specified by the user
         # if self.excitation_force.dt is None:

--- a/bemio/io/aqwa.py
+++ b/bemio/io/aqwa.py
@@ -40,7 +40,7 @@ class AqwaOutput(object):
     '''
     def __init__(self, hydro_file, list_file, scale=False):
 
-        print '\nReading the AQWA results in the ' + hydro_file + ' file'
+        print('\nReading the AQWA results in the ' + hydro_file + ' file')
 
         self.files = bem.generate_file_names(hydro_file)
         self.scaled_at_read = scale
@@ -194,10 +194,10 @@ class AqwaOutput(object):
                 bod_count += 1
 
 
-        for i in xrange(num_bodies):
+        for i in range(num_bodies):
 
 
-            print 'body' + str(i+1) + ':'
+            print('body' + str(i+1) + ':')
 
             self.body[i] = bem.HydrodynamicData()
             self.body[i].scaled = self.scaled
@@ -224,14 +224,14 @@ class AqwaOutput(object):
             self.body[i].bem_raw_data = raw
 
             self.body[i].am.all = np.copy(added_mass[i+1])
-            print '   * Setting added mass at infinite frequency to added mass at omega = ' + str(frequencies[-1])
+            print('   * Setting added mass at infinite frequency to added mass at omega = ' + str(frequencies[-1]))
             self.body[i].am.inf = np.copy(added_mass[i+1][:,:,-1])
-            print '   * Setting added mass at zero frequency to added mass at omega = ' + str(frequencies[0])
+            print('   * Setting added mass at zero frequency to added mass at omega = ' + str(frequencies[0]))
             self.body[i].am.zero = np.copy(added_mass[i+1][:,:,0])
             self.body[i].rd.all = radiation_damping[i+1]
             self.body[i].ex.mag = excitation_magnitude[i+1]
             self.body[i].ex.phase = excitation_phase[i+1]
-            print '   * Calculating real and imaginary excitation  components.'
+            print('   * Calculating real and imaginary excitation  components.')
             self.body[i].ex.re = self.body[i].ex.mag * np.cos(self.body[i].ex.phase*np.pi/180.)
             self.body[i].ex.im = self.body[i].ex.mag * np.sin(self.body[i].ex.phase*np.pi/180.)
 

--- a/bemio/io/aqwa.py
+++ b/bemio/io/aqwa.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
 import numpy as np
-
 from bemio.data_structures import bem
 
 from math import ceil

--- a/bemio/io/nemoh.py
+++ b/bemio/io/nemoh.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import division
+
 
 import os
 
@@ -60,7 +60,7 @@ class NemohOutput(object):
         self.scaled = True
         self.dir = os.path.abspath(sim_dir)
 
-        print '\nReading NEMOH output in the ' + self.dir + ' directory'
+        print('\nReading NEMOH output in the ' + self.dir + ' directory')
 
         self.files = bem.generate_file_names(os.path.join(self.dir,cal_file))
         self.files['Nemoh']     = os.path.join(self.dir,cal_file)
@@ -75,7 +75,7 @@ class NemohOutput(object):
         try:
             self.files['IRF'] = os.path.join(self.dir,results_dir,'IRF.tec')
         except:
-            print '\tNo IRF forces or infinite frequency added mass forces read because the ' + self.files['IRF'] + ' was not found'
+            print('\tNo IRF forces or infinite frequency added mass forces read because the ' + self.files['IRF'] + ' was not found')
 
         # Initialize data ovject
         self.body = {}
@@ -110,7 +110,7 @@ class NemohOutput(object):
         '''
         Function to load hydrodynamic data into HydrodynamicData object
         '''
-        for i in xrange(self.cal.n_bods):
+        for i in range(self.cal.n_bods):
             self.body[i] = bem.HydrodynamicData()
             self.body[i].am.all = self.am[0+6*i:6+6*i,:]
             self.body[i].rd.all = self.rd[0+6*i:6+6*i,:]
@@ -189,7 +189,7 @@ class NemohOutput(object):
         self.cal.add_lines = {}
         self.cal.cg = {}
         line_count = 0
-        for i in xrange(self.cal.n_bods):
+        for i in range(self.cal.n_bods):
             name_with_path = cal[8+line_count].split()[0]
             self.cal.name[i] = os.path.splitext(os.path.basename(name_with_path))[0]
             self.cal.points_panels[i] = cal[9+line_count].split()[0:2]
@@ -197,7 +197,7 @@ class NemohOutput(object):
             self.cal.dof[i] = []
             self.cal.forces[i] = []
             self.cal.add_lines[i] = []
-            for j in xrange(self.cal.n_dof[i]):
+            for j in range(self.cal.n_dof[i]):
                 self.cal.dof[i].append(cal[11+line_count+j])
 
                 if int(self.cal.dof[i][-1].split()[0]) == 2:
@@ -205,12 +205,12 @@ class NemohOutput(object):
 
             self.cal.n_forces[i] = int(cal[10+line_count+self.cal.n_dof[i]+1].split()[0])
 
-            for j in xrange(self.cal.n_forces[i]):
+            for j in range(self.cal.n_forces[i]):
                     self.cal.forces[i].append(cal[11+line_count+j+self.cal.n_dof[i]+1])
 
             self.cal.n_add_lines[i] = int(cal[10 + line_count + self.cal.n_dof[i] + self.cal.n_forces[i] + 2].split()[0])
 
-            for j in xrange(self.cal.n_add_lines[i]):
+            for j in range(self.cal.n_add_lines[i]):
                     self.cal.add_lines[i].append(cal[11+line_count+j+self.cal.n_dof[i]+self.cal.n_forces[i]+1])
 
             line_count += self.cal.n_dof[i] + self.cal.n_forces[i] + self.cal.n_add_lines[i] + 6
@@ -247,7 +247,7 @@ class NemohOutput(object):
 
         if self.body[body_num].scaled is False:
             self.body[body_num].k /= (self.body[body_num].rho * self.body[body_num].g)
-            print '\tSpring stiffness for body ' + self.body[body_num].name + ' scaled by read_kh method'
+            print('\tSpring stiffness for body ' + self.body[body_num].name + ' scaled by read_kh method')
 
     def read_hydrostatics(self, file, body_num):
         '''
@@ -326,7 +326,7 @@ def _read_tec(file, data_type):
 
 
     # Sort the zones from the .tec file
-    zones = proc.keys()
+    zones = list(proc.keys())
     zones.sort()
 
     # Set the frequencies and calculate number of freqs
@@ -342,13 +342,13 @@ def _read_tec(file, data_type):
         b = []
 
     if data_type == 1:
-        for j in xrange(n_vars):
+        for j in range(n_vars):
             a[j,0,:] = proc[zones[-1]].field(1+j*2)
             b[j,0,:] = proc[zones[-1]].field(2+j*2)
 
     if data_type == 2:
         for i, zone in enumerate(zones):
-            for j in xrange(n_vars):
+            for j in range(n_vars):
                 a[i,j] = proc[zone].field(1+j*2)[0]
 
     return (a, b, w, raw)
@@ -379,7 +379,7 @@ def _read_radiation(file, ):
 
 
     # Sort the zones from the .tec file
-    zones = proc.keys()
+    zones = list(proc.keys())
     zones.sort()
 
     # Set the frequencies and calculate number of freqs
@@ -392,7 +392,7 @@ def _read_radiation(file, ):
 
     # Populate matrices
     for i, zone in enumerate(zones):
-        for j in xrange(n_vars):
+        for j in range(n_vars):
             a[i,j,:] = proc[zone].field(1+j*2)
             b[i,j,:] = proc[zone].field(2+j*2)
 
@@ -433,7 +433,7 @@ def _read_excitation(file, ):
 
 
     # Sort the zones from the .tec file
-    zones = proc.keys()
+    zones = list(proc.keys())
     zones.sort()
 
     # Set the frequencies and calculate number of freqs
@@ -446,7 +446,7 @@ def _read_excitation(file, ):
 
     # Populate matrices
     for i, zone in enumerate(zones):
-        for j in xrange(n_vars):
+        for j in range(n_vars):
             a[j,i,:] = proc[zone].field(1+j*2)
             b[j,i,:] = proc[zone].field(2+j*2)
 

--- a/bemio/io/nemoh.py
+++ b/bemio/io/nemoh.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+from __future__ import division
 
 import os
 
@@ -168,7 +170,7 @@ class NemohOutput(object):
 
         # Read wave directions
         temp = cal[-6]
-        self.cal.wave_dir_n = np.float(temp.split()[0])
+        self.cal.wave_dir_n = np.int32(temp.split()[0])
         self.cal.wave_dir_start = np.float(temp.split()[1])
         self.cal.wave_dir_end = np.float(temp.split()[2])
         self.cal.wave_dir = np.linspace(self.cal.wave_dir_start,self.cal.wave_dir_end,self.cal.wave_dir_n)
@@ -326,7 +328,7 @@ def _read_tec(file, data_type):
 
 
     # Sort the zones from the .tec file
-    zones = list(proc.keys())
+    zones = list(proc)
     zones.sort()
 
     # Set the frequencies and calculate number of freqs

--- a/bemio/io/output.py
+++ b/bemio/io/output.py
@@ -45,7 +45,7 @@ def write_hdf5(bemio_obj,out_file=None):
         out_file = bemio_obj.files['hdf5']
 
 
-    print 'Writing HDF5 data to ' + out_file
+    print('Writing HDF5 data to ' + out_file)
 
 
     with h5py.File(out_file, "w") as f:
@@ -92,9 +92,9 @@ def write_hdf5(bemio_obj,out_file=None):
                 irf_rad_l_correct_loc.attrs['description'] = 'Time derivative of the impulse response function'
 
 
-                for m in xrange(bemio_obj.body[key].am.all.shape[0]):
+                for m in range(bemio_obj.body[key].am.all.shape[0]):
 
-                    for n in xrange(bemio_obj.body[key].am.all.shape[1]):
+                    for n in range(bemio_obj.body[key].am.all.shape[1]):
 
                         irf_rad_l_comp_correct_loc = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/radiation_damping/impulse_response_fun/components/L/' + str(m+1) + '_' + str(n+1),data=np.array([bemio_obj.body[key].rd.irf.t,bemio_obj.body[key].rd.irf.L[m,n,:]]).transpose())
                         irf_rad_l_comp_correct_loc.attrs['units'] = ''
@@ -105,7 +105,7 @@ def write_hdf5(bemio_obj,out_file=None):
                         irf_rad_k_comp_correct_loc.attrs['description'] = 'Components of the ddt(IRF): K'
             except:
 
-                print '\tRadiation IRF functions for ' + bemio_obj.body[key].name + ' were not written.'
+                print('\tRadiation IRF functions for ' + bemio_obj.body[key].name + ' were not written.')
 
             # Excitation IRF
             try:
@@ -117,9 +117,9 @@ def write_hdf5(bemio_obj,out_file=None):
                 irf_ex_t = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/excitation/impulse_response_fun/w',data=bemio_obj.body[key].ex.irf.w)
                 irf_ex_w = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/excitation/impulse_response_fun/t',data=bemio_obj.body[key].ex.irf.t)
 
-                for m in xrange(bemio_obj.body[key].ex.mag.shape[0]):
+                for m in range(bemio_obj.body[key].ex.mag.shape[0]):
 
-                    for n in xrange(bemio_obj.body[key].ex.mag.shape[1]):
+                    for n in range(bemio_obj.body[key].ex.mag.shape[1]):
 
                         irf_ex_f_comp = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/excitation/impulse_response_fun/components/f/' + str(m+1) + '_' + str(n+1),data=np.array([bemio_obj.body[key].ex.irf.t,bemio_obj.body[key].ex.irf.f[m,n,:]]).transpose())
                         irf_ex_f_comp.attrs['units'] = ''
@@ -127,7 +127,7 @@ def write_hdf5(bemio_obj,out_file=None):
 
             except:
 
-                print '\tExcitation IRF functions for ' + bemio_obj.body[key].name + ' were not written.'
+                print('\tExcitation IRF functions for ' + bemio_obj.body[key].name + ' were not written.')
 
             try:
 
@@ -155,9 +155,9 @@ def write_hdf5(bemio_obj,out_file=None):
                 it.attrs['units'] = ''
                 it.attrs['description'] = 'Order of state space realization'
 
-                for m in xrange(bemio_obj.body[key].am.all.shape[0]):
+                for m in range(bemio_obj.body[key].am.all.shape[0]):
 
-                    for n in xrange(bemio_obj.body[key].am.all.shape[1]):
+                    for n in range(bemio_obj.body[key].am.all.shape[1]):
 
                         ss_A = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/radiation_damping/state_space/A/components/' + str(m+1) + '_' + str(n+1),data=bemio_obj.body[key].rd.ss.A[m,n,:,:])
                         ss_A.attrs['units'] = ''
@@ -177,7 +177,7 @@ def write_hdf5(bemio_obj,out_file=None):
 
             except:
 
-                print '\tRadiation state space coefficients for ' + bemio_obj.body[key].name + ' were not written.'
+                print('\tRadiation state space coefficients for ' + bemio_obj.body[key].name + ' were not written.')
 
             k = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/linear_restoring_stiffness',data=bemio_obj.body[key].k)
             k.attrs['units'] = ''
@@ -199,9 +199,9 @@ def write_hdf5(bemio_obj,out_file=None):
             exIm.attrs['units'] = ''
             exIm.attrs['description'] = 'Imaginary component of excitation force'
 
-            for m in xrange(bemio_obj.body[key].ex.mag.shape[0]):
+            for m in range(bemio_obj.body[key].ex.mag.shape[0]):
 
-                for n in xrange(bemio_obj.body[key].ex.mag.shape[1]):
+                for n in range(bemio_obj.body[key].ex.mag.shape[1]):
 
                     irf_ex_f_comp = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/excitation//components/mag/' + str(m+1) + '_' + str(n+1),data=np.array([bemio_obj.body[key].T,bemio_obj.body[key].ex.mag[m,n,:]]).transpose())
                     irf_ex_f_comp = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/excitation//components/phase/' + str(m+1) + '_' + str(n+1),data=np.array([bemio_obj.body[key].T,bemio_obj.body[key].ex.phase[m,n,:]]).transpose())
@@ -256,9 +256,9 @@ def write_hdf5(bemio_obj,out_file=None):
             am.attrs['units for rotational degrees of freedom'] = 'kg-m^2'
             am.attrs['description'] = 'Added mass. Frequency is the third dimension of the data structure.'
 
-            for m in xrange(bemio_obj.body[key].am.all.shape[0]):
+            for m in range(bemio_obj.body[key].am.all.shape[0]):
 
-                for n in xrange(bemio_obj.body[key].am.all.shape[1]):
+                for n in range(bemio_obj.body[key].am.all.shape[1]):
 
                     amComp = f.create_dataset('body' + str(key+1) + '/hydro_coeffs/added_mass/components/' + str(m+1) + '_' + str(n+1),data=np.array([bemio_obj.body[key].T, bemio_obj.body[key].am.all[m,n,:]]).transpose())
                     amComp.attrs['units'] = ''

--- a/bemio/io/output.py
+++ b/bemio/io/output.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import print_function
 import h5py
 import numpy as np
 from bemio.__version__ import base

--- a/bemio/io/wamit.py
+++ b/bemio/io/wamit.py
@@ -69,7 +69,7 @@ class WamitOutput(object):
         '''Internal function to read WAMIT output file into the class. that is called during __init__
         '''
 
-        print '\nReading the WAMIT results in the ' + self.files['out'] + ' file'
+        print('\nReading the WAMIT results in the ' + self.files['out'] + ' file')
 
         with open(self.files['out'],'rU') as fid:
 
@@ -128,7 +128,7 @@ class WamitOutput(object):
             # If there are two bodies in the WAMIT run
             if "Input from Geometric Data Files:" in line:
 
-                for j in xrange(20): # look for bodies within the next 20 lines
+                for j in range(20): # look for bodies within the next 20 lines
 
                     if "N=" in raw[i+j]:
 
@@ -139,7 +139,7 @@ class WamitOutput(object):
             # Read the body positions
             # if "Total panels:" in line or "NPATCH:" in line:
             if "XBODY" in line:
-                for j in xrange(12): # look for position within the next 15 lines - will only work for wamit files of about 5 bodies
+                for j in range(12): # look for position within the next 15 lines - will only work for wamit files of about 5 bodies
 
                     if 'XBODY =' in raw[i+j]:
                         '''
@@ -379,8 +379,8 @@ class WamitOutput(object):
             scattering = np.loadtxt(self.files['3sc'],skiprows=1)
             line_count = 0
 
-            for freq_n in xrange(T.size):
-                for beta_n in xrange(wave_dir.size):
+            for freq_n in range(T.size):
+                for beta_n in range(wave_dir.size):
                     wave_dir_hold =  scattering[line_count][1]
                     while line_count < scattering.shape[0] and scattering[line_count][1] == wave_dir_hold:
                         comp = int(scattering[line_count][2])-1
@@ -392,7 +392,7 @@ class WamitOutput(object):
                         line_count += 1
 
         else:
-            print '\tThe file ' + self.files['3sc'] + ' does not exist... not reading scattering coefficients.'
+            print('\tThe file ' + self.files['3sc'] + ' does not exist... not reading scattering coefficients.')
 
         if os.path.exists(self.files['3fk']):
             fk_re = np.zeros([6*num_bodies,wave_dir.size,T.size])
@@ -403,8 +403,8 @@ class WamitOutput(object):
             fk = np.loadtxt(self.files['3fk'],skiprows=1)
             line_count = 0
 
-            for freq_n in xrange(T.size):
-                for beta_n in xrange(wave_dir.size):
+            for freq_n in range(T.size):
+                for beta_n in range(wave_dir.size):
                     wave_dir_hold =  fk[line_count][1]
                     while line_count < fk.shape[0] and fk[line_count][1] == wave_dir_hold:
                         comp = int(fk[line_count][2])-1
@@ -416,10 +416,10 @@ class WamitOutput(object):
                         line_count += 1
 
         else:
-            print '\tThe file ' + self.files['3fk'] + ' does not exist... not reading froud krylof coefficients.'
+            print('\tThe file ' + self.files['3fk'] + ' does not exist... not reading froud krylof coefficients.')
 
         # Load data into the hydrodata structure
-        for i in xrange(num_bodies):
+        for i in range(num_bodies):
             self.body[i] = bem.HydrodynamicData()
             self.body[i].scaled = self.scaled
             self.body[i].g = self.g
@@ -443,7 +443,7 @@ class WamitOutput(object):
             else:
 
                 self.body[i].am.inf = np.nan*np.zeros([6*num_bodies,6*num_bodies,self.body[i].T.size])
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain infinite frequency added mass coefficients'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain infinite frequency added mass coefficients')
 
 
             if 'am_zero' in locals():
@@ -453,7 +453,7 @@ class WamitOutput(object):
             else:
 
                 self.body[i].am.zero = np.nan*np.zeros([6*num_bodies,6*num_bodies,self.body[i].T.size])
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain zero frequency added mass coefficients'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain zero frequency added mass coefficients')
 
 
             if 'am_all' in locals():
@@ -462,7 +462,7 @@ class WamitOutput(object):
             else:
 
                 self.body[i].am.all = np.nan*np.zeros([6*num_bodies,6*num_bodies,self.body[i].T.size])
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any frequency dependent added mass coefficients'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any frequency dependent added mass coefficients')
 
 
             if 'rd_all' in locals():
@@ -472,7 +472,7 @@ class WamitOutput(object):
             else:
 
                 self.body[i].rd.all = np.nan*np.zeros([6*num_bodies,6*num_bodies,self.body[i].T.size])
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any frequency dependent radiation damping coefficients'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any frequency dependent radiation damping coefficients')
 
             if 'ex_all' in locals() and self.ex_calc == 'diffraction' :
                 
@@ -490,7 +490,7 @@ class WamitOutput(object):
 
             else:
 
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any excitation coefficients'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any excitation coefficients')
 
             if 'sc_mag' in locals():
                 self.body[i].ex.sc.mag = sc_mag[6*i:6+6*i,:,:]
@@ -521,7 +521,7 @@ class WamitOutput(object):
 
             else:
 
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any rao data'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any rao data')
 
             if 'ssy_all' in locals():
 
@@ -532,7 +532,7 @@ class WamitOutput(object):
 
             else:
 
-                print 'Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any rao data'
+                print('Warning: body ' + str(i) + ' - The WAMTI .out file specified does not contain any rao data')
 
             self.body[i].bem_raw_data = raw
             self.body[i].bem_code = code

--- a/bemio/io/wamit.py
+++ b/bemio/io/wamit.py
@@ -15,6 +15,8 @@
 This moduel provides functionality to read and interact with WAMIT simulation
 output data
 '''
+from __future__ import print_function
+
 import os
 
 import numpy as np

--- a/bemio/mesh_utilities/mesh.py
+++ b/bemio/mesh_utilities/mesh.py
@@ -46,7 +46,7 @@ try:
 
 except:
 
-    print 'The VTK Python module is required for a significant amnount of functionality in this module. Many functions will not be available for use.'
+    print('The VTK Python module is required for a significant amnount of functionality in this module. Many functions will not be available for use.')
 
 
 
@@ -198,7 +198,7 @@ class PanelMesh(object):
             self._hydrostatic_stiffness[4,4] += self.volume_x * self.center_of_buoyancy[2] - self.volume_x * self.center_of_gravity[2]
             self._hydrostatic_stiffness[4,5] += -self.volume_x * self.center_of_buoyancy[1] + self.volume_x * self.center_of_gravity[1]
 
-            print 'Calculated hydorstatic stiffness'
+            print('Calculated hydorstatic stiffness')
 
         return self._hydrostatic_stiffness
 
@@ -224,7 +224,7 @@ class PanelMesh(object):
                     z_b += self.normals[face_n][2]*self.centroid[face_n][2]**2*self.cell_surface_area[face_n]
             self._center_of_buoyancy = 1./(2.*self.volume_x )*np.array([x_b, y_b, z_b])
 
-            print 'Calculated the center of buoyancy'
+            print('Calculated the center of buoyancy')
 
         return self._center_of_buoyancy
 
@@ -232,7 +232,7 @@ class PanelMesh(object):
     def normals(self, ):
         if self._normals is None:
             self._normals = {}
-            for face_n in xrange(self.faces.shape[0]):
+            for face_n in range(self.faces.shape[0]):
                 a = self.points[self.faces[face_n][1]] - self.points[self.faces[face_n][0]]
                 b = self.points[self.faces[face_n][2]] - self.points[self.faces[face_n][1]]
                 self._normals[face_n] = np.cross(a,b)
@@ -249,7 +249,7 @@ class PanelMesh(object):
 
                 self._normals[face_n] /= np.linalg.norm(self._normals[face_n])
 
-            print 'Calculated mesh cell normals'
+            print('Calculated mesh cell normals')
 
         return self._normals
 
@@ -261,14 +261,14 @@ class PanelMesh(object):
         '''
         if self._cell_surface_area is None:
             self._cell_surface_area = {}
-            for face_n in xrange(self.faces.shape[0]):
+            for face_n in range(self.faces.shape[0]):
                 a = self.points[self.faces[face_n][1]] - self.points[self.faces[face_n][0]]
                 b = self.points[self.faces[face_n][2]] - self.points[self.faces[face_n][1]]
                 c = self.points[self.faces[face_n][3]] - self.points[self.faces[face_n][2]]
                 d = self.points[self.faces[face_n][0]] - self.points[self.faces[face_n][3]]
                 self._cell_surface_area[face_n] = 1./2. * ( np.linalg.norm(np.cross(a,b)) + np.linalg.norm(np.cross(c,d)) )
 
-            print 'Calculated surface cell area'
+            print('Calculated surface cell area')
 
         return self._cell_surface_area
 
@@ -278,7 +278,7 @@ class PanelMesh(object):
 
             self._surface_area = sum(self.cell_surface_area.values())
 
-            print 'Calculated surface area'
+            print('Calculated surface area')
 
         return self._surface_area
 
@@ -296,7 +296,7 @@ class PanelMesh(object):
             mass_props.SetInputDataObject(tri_mesh)
             self._volume_vtk = mass_props.GetVolume()
 
-            print 'Calculated mesh volume using VTK library'
+            print('Calculated mesh volume using VTK library')
 
         return self._volume_vtk
 
@@ -312,7 +312,7 @@ class PanelMesh(object):
                           self.points[face[2]],
                           self.points[face[3]]]
 
-                points = map(np.asarray, set(map(tuple, points))) # This removes duplicate points... somehow
+                points = list(map(np.asarray, set(map(tuple, points)))) # This removes duplicate points... somehow
                 self._centroid[face_n] = np.mean(points,axis=0)
 
         return self._centroid
@@ -348,7 +348,7 @@ class PanelMesh(object):
             mass_props.SetInputDataObject(tri_mesh)
             self._surface_area_vtk = mass_props.GetSurfaceArea()
 
-            print 'Calculated mesh surface area using VTK Python bindings'
+            print('Calculated mesh surface area using VTK Python bindings')
 
         return self._surface_area_vtk
 
@@ -423,7 +423,7 @@ class PanelMesh(object):
         com.Update()
         self.center_of_gravity = com.GetCenter()
 
-        print 'Calculated center of gravity assuming uniform material density'
+        print('Calculated center of gravity assuming uniform material density')
 
     def view(self, color=[0.5,1,0.5], opacity=1.0, save_png=False, camera_pos=[50,50,50], interact=True):
         '''Function to view the mesh using the VTK library
@@ -505,7 +505,7 @@ class PanelMesh(object):
             writer.SetInputDataObject(w2if.GetOutput())
             writer.Write()
 
-            print 'Wrote mesh image to: ' + self.files['png']
+            print('Wrote mesh image to: ' + self.files['png'])
 
         if interact is True:
             iren.Start()
@@ -597,7 +597,7 @@ class PanelMesh(object):
         centroid = vtk.vtkPolyData()
         centroid.SetPoints(centroid_points)
         centroid.SetVerts(vertices)
-        n=np.array(self.normals.values())
+        n=np.array(list(self.normals.values()))
         nv = vtk.util.numpy_support.numpy_to_vtk(n)
         pv =centroid.GetPointData()
         _ = pv.SetNormals(nv)
@@ -779,7 +779,7 @@ class PanelMesh(object):
             writer.SetFileName(self.files['png'])
             writer.SetInputDataObject(w2if.GetOutput())
             writer.Write()
-            print 'Wrote mesh image to: ' + self.files['png']
+            print('Wrote mesh image to: ' + self.files['png'])
         # Set interaction mode
         if interact is True:
             iren.Start()
@@ -835,7 +835,7 @@ class PanelMesh(object):
         self.points = self.points*scale_vect
         self.scale_vect = scale_vect
         self._create_vtp_mesh()
-        print 'Scaled mesh by: ' + str(scale_vect)
+        print('Scaled mesh by: ' + str(scale_vect))
 
     def translate(self,translation_vect,translate_cog=True):
         '''Function used to translate mesh obvjects in the x, y, and z directions.
@@ -863,7 +863,7 @@ class PanelMesh(object):
         if translate_cog is True:
             self.center_of_gravity += translation_vect
 
-        print 'Translated mesh by: ' + str(translation_vect) + '\nCenter of gravity is: ' + str(self.center_of_gravity)
+        print('Translated mesh by: ' + str(translation_vect) + '\nCenter of gravity is: ' + str(self.center_of_gravity))
 
     def xzmirror(self,):
         '''Function used to mirror the mesh object about the xz plane.
@@ -914,7 +914,7 @@ class PanelMesh(object):
             return unique_a,inverse_a
         unique_points,inverse_points = unique_rows(self.points)
         map = np.zeros([len(inverse_points),2])
-        map[:,0] = np.array(range(len(self.points)))
+        map[:,0] = np.array(list(range(len(self.points))))
         map[:,1] = inverse_points
         faces_org = self.faces.flatten()
         faces_new = np.zeros(np.shape(faces_org))
@@ -978,7 +978,7 @@ class PanelMesh(object):
         writer.SetDataModeToAscii()
         writer.Write()
 
-        print 'Wrote VTK PolyData mesh to: ' + str(self.files['vtp'])
+        print('Wrote VTK PolyData mesh to: ' + str(self.files['vtp']))
 
     def _write_nemoh(self):
         '''Internal function to write NEMOH mesh files
@@ -986,17 +986,17 @@ class PanelMesh(object):
         with open(self.files['nemoh'],'w') as fid:
             fid.write('2 0') # This should not be hard coded
             fid.write('\n')
-            for i in xrange(self.points.shape[0]):
+            for i in range(self.points.shape[0]):
                 fid.write(str(i+1) + ' ' +str(self.points[i]).replace('[','').replace(']',''))
                 fid.write('\n')
             fid.write('0 0 0 0')
             fid.write('\n')
-            for i in xrange(self.faces.shape[0]):
+            for i in range(self.faces.shape[0]):
                 fid.write(str(self.faces[i]+1).replace('[','').replace(']','').replace('.',''))
                 fid.write('\n')
             fid.write('0 0 0 0')
 
-        print 'Wrote NEMOH mesh to: ' + str(self.files['nemoh'])
+        print('Wrote NEMOH mesh to: ' + str(self.files['nemoh']))
 
     def _write_gdf(self):
         '''Internal function to write WAMIT mesh files
@@ -1019,7 +1019,7 @@ class PanelMesh(object):
                     for j,pointKey in enumerate(faceMod):
                         fid.write(str(self.points[pointKey]).replace(',','').replace('[','').replace(']','') + '\n')
 
-        print 'Wrote WAMIT mesh to: ' + str(self.files['wamit'])
+        print('Wrote WAMIT mesh to: ' + str(self.files['wamit']))
 
     def _calc_component_vol(self, ):
         '''Internal function to calculate mesh volume using the methods
@@ -1030,14 +1030,14 @@ class PanelMesh(object):
         self._volume_z = 0.
         volume = 0.
 
-        for face_n in xrange(self.faces.shape[0]):
+        for face_n in range(self.faces.shape[0]):
             volume += self.normals[face_n]*self.centroid[face_n]*self.cell_surface_area[face_n]
 
         self._volume_x = volume[0]
         self._volume_y = volume[1]
         self._volume_z = volume[2]
 
-        print 'Calculated x y and z mesh volumes'
+        print('Calculated x y and z mesh volumes')
 
 def _read_gdf(file_name):
     '''Internal function to read gdf wamit meshes
@@ -1103,15 +1103,15 @@ def _read_vtp(file_name):
     mesh_data.num_faces =    int(readerOut.GetNumberOfCells())
     mesh_data.num_points =   int(readerOut.GetNumberOfPoints())
 
-    for i in xrange(mesh_data.num_points):
+    for i in range(mesh_data.num_points):
         mesh_data.points.append(readerOut.GetPoint(i))
     mesh_data.points = np.array(mesh_data.points)
 
-    for i in xrange(mesh_data.num_faces):
+    for i in range(mesh_data.num_faces):
         c = readerOut.GetCell(i)
         numCellPoints = int(c.GetNumberOfPoints())
         idsTemp = []
-        for i in xrange(numCellPoints):
+        for i in range(numCellPoints):
             idsTemp.append(int(c.GetPointId(i)))
         mesh_data.faces.append(np.array(idsTemp))
     mesh_data.faces = np.array(mesh_data.faces)
@@ -1184,7 +1184,7 @@ def read(file_name):
 
         >>> mesh.open()
     '''
-    print 'Reading mesh file: ' + str(file_name)
+    print('Reading mesh file: ' + str(file_name))
 
     file_name = os.path.abspath(file_name)
     (f_name,f_ext) = os.path.splitext(file_name)
@@ -1215,7 +1215,7 @@ def read(file_name):
 
         mesh_data._create_vtp_mesh()
 
-    print 'Successfully read mesh file: ' + str(file_name)
+    print('Successfully read mesh file: ' + str(file_name))
 
     return mesh_data
 
@@ -1295,6 +1295,6 @@ def cut_mesh(mesh_obj, plane_ind=2, plane_loc=-1e-5, cut_dir=1.):
 
     cut_mesh.files_base = os.path.splitext(cut_mesh.file_name)[0] + '_cut_mesh_bemio_output'
 
-    print 'Cut mesh in direction [' + str(plane_ind) + '] in direction [' + str(cut_dir) + '] at the location [' + str(plane_loc) + ']'
+    print('Cut mesh in direction [' + str(plane_ind) + '] in direction [' + str(cut_dir) + '] at the location [' + str(plane_loc) + ']')
 
     return cut_mesh

--- a/bemio/mesh_utilities/mesh.py
+++ b/bemio/mesh_utilities/mesh.py
@@ -26,6 +26,9 @@ The functionality provided includes:
 
 .. Note::
 """
+from __future__ import print_function
+from builtins import map
+
 import numpy as np
 
 import imp

--- a/bemio/mesh_utilities/mesh.py
+++ b/bemio/mesh_utilities/mesh.py
@@ -27,7 +27,6 @@ The functionality provided includes:
 .. Note::
 """
 from __future__ import print_function
-from builtins import map
 
 import numpy as np
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,8 +18,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'bemio'
-copyright = u'2015, National Renewable Energy Laboratory and Sandia National Laboratories'
+project = 'bemio'
+copyright = '2015, National Renewable Energy Laboratory and Sandia National Laboratories'
 version = 'v1.0'
 
 # The full version, including alpha/beta/rc tags.
@@ -48,8 +48,8 @@ html_theme_options = {}
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('bemio_doc', 'bemio', u'bemio Documentation',
-     [u'Michael Lawson, National Renewable Energy Laboratory'], 1)
+    ('bemio_doc', 'bemio', 'bemio Documentation',
+     ['Michael Lawson, National Renewable Energy Laboratory'], 1)
 ]
 
 # Custom paths

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,8 +18,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'bemio'
-copyright = '2015, National Renewable Energy Laboratory and Sandia National Laboratories'
+project = u'bemio'
+copyright = u'2015, National Renewable Energy Laboratory and Sandia National Laboratories'
 version = 'v1.0'
 
 # The full version, including alpha/beta/rc tags.
@@ -48,8 +48,8 @@ html_theme_options = {}
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('bemio_doc', 'bemio', 'bemio Documentation',
-     ['Michael Lawson, National Renewable Energy Laboratory'], 1)
+    ('bemio_doc', 'bemio', u'bemio Documentation',
+     [u'Michael Lawson, National Renewable Energy Laboratory'], 1)
 ]
 
 # Custom paths

--- a/doc/source/conf_sample.py
+++ b/doc/source/conf_sample.py
@@ -45,8 +45,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'sampledoc'
-copyright = u'2009, John Hunter, Fernando Perez, Michael Droettboom'
+project = 'sampledoc'
+copyright = '2009, John Hunter, Fernando Perez, Michael Droettboom'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -180,8 +180,8 @@ htmlhelp_basename = 'sampledocdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'sampledoc.tex', u'sampledoc Documentation',
-   u'John Hunter, Fernando Perez, Michael Droettboom', 'manual'),
+  ('index', 'sampledoc.tex', 'sampledoc Documentation',
+   'John Hunter, Fernando Perez, Michael Droettboom', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/doc/source/conf_sample.py
+++ b/doc/source/conf_sample.py
@@ -45,8 +45,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'sampledoc'
-copyright = '2009, John Hunter, Fernando Perez, Michael Droettboom'
+project = u'sampledoc'
+copyright = u'2009, John Hunter, Fernando Perez, Michael Droettboom'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -180,8 +180,8 @@ htmlhelp_basename = 'sampledocdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'sampledoc.tex', 'sampledoc Documentation',
-   'John Hunter, Fernando Perez, Michael Droettboom', 'manual'),
+  ('index', 'sampledoc.tex', u'sampledoc Documentation',
+   u'John Hunter, Fernando Perez, Michael Droettboom', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/install_test.py
+++ b/install_test.py
@@ -5,20 +5,20 @@ import sys
 
 def run_test_case(test_case):
 
-	print '\n****Running the ' + str(test_case) + ' case****'
+	print('\n****Running the ' + str(test_case) + ' case****')
 	starting_dir = os.path.abspath(os.curdir)
 
 	try:
 
 		os.chdir(test_case)
-		execfile('run.py')
+		exec(compile(open('run.py', "rb").read(), 'run.py', 'exec'))
 		os.chdir(starting_dir)
-		print '****The ' +  str(test_case) + ' test case ran successfully****\n'
+		print('****The ' +  str(test_case) + ' test case ran successfully****\n')
 		status = str(test_case) + ': SUCCESS'
 
 	except:
 
-		print '****The ' +  str(test_case) + ' test case failed. For the specific information on the error run the ' + str(test_case) + ' test case manually****\n'
+		print('****The ' +  str(test_case) + ' test case failed. For the specific information on the error run the ' + str(test_case) + ' test case manually****\n')
 		status = str(test_case) + ': FAILED'
 		os.chdir(starting_dir)
 
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
 	if len(sys.argv) == 2 and sys.argv[1] == 'all':
 
-		print 'Running all test cases:\n'
+		print('Running all test cases:\n')
 		status.append(run_test_case('tutorials/wamit/ecm_ellipsoid'))
 		status.append(run_test_case('tutorials/wamit/sphere'))
 		status.append(run_test_case('tutorials/wamit/oswec'))
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
 	else:
 
-		print 'Running standard test cases:\n'
+		print('Running standard test cases:\n')
 
 	status.append(run_test_case('tutorials/wamit/COER_hydrodynamic_modeling_comp'))
 	status.append(run_test_case('tutorials/wamit/wec3'))
@@ -51,6 +51,6 @@ if __name__ == "__main__":
 	status.append(run_test_case('tutorials/aqwa'))
 
 
-	print 'Test cases runs completed:'
+	print('Test cases runs completed:')
 	for i, status_i in enumerate(status):
-		print '\t' + status_i
+		print('\t' + status_i)

--- a/tutorials/aqwa/run.py
+++ b/tutorials/aqwa/run.py
@@ -5,7 +5,7 @@ from bemio.io.output import write_hdf5
 aqwa_data = read(hydro_file='./data/aqwa_example_data.AH1',list_file='./data/aqwa_example_data.LIS')
 
 # Calculate IRF and state space coefficients
-for i in xrange(aqwa_data.body[0].num_bodies):
+for i in range(aqwa_data.body[0].num_bodies):
 	aqwa_data.body[i].calc_irf_radiation(t_end=50,n_t=101,n_w=101)
 	aqwa_data.body[i].calc_irf_excitation()
 	# aqwa_data.body[i].calc_ss_radiation(max_order=3, r2_thresh=0.5 )

--- a/tutorials/nemoh/run.py
+++ b/tutorials/nemoh/run.py
@@ -17,7 +17,7 @@ nemoh_data_two_body = read(sim_dir='./data/two_body', cal_file='Nemoh.cal', resu
 nemoh_data_two_body.read_hydrostatics(body_num=1,file='./data/two_body/Mesh/Hydrostatics_1.dat')
 nemoh_data_two_body.read_kh(body_num=1, file='./data/two_body/Mesh/KH_1.dat')
 
-for i in xrange(nemoh_data_two_body.body[0].num_bodies):
+for i in range(nemoh_data_two_body.body[0].num_bodies):
 	nemoh_data_two_body.body[i].calc_irf_radiation(t_end=20., n_t=1001, n_w=501)
 	nemoh_data_two_body.body[i].calc_irf_excitation(t_end=20., n_t=1001, n_w=501)
 	# nemoh_data_two_body.body[i].calc_ss_radiation()

--- a/tutorials/utilities/wave_excitation/run.py
+++ b/tutorials/utilities/wave_excitation/run.py
@@ -28,5 +28,6 @@ try:
     plt.plot(ex_f.excitation_force.t, ex_f.excitation_force.f, 'r--',label='bemio')
     plt.plot(fast[:,0],fast[:,56],label='FAST')
     plt.legend()
+    print('Done.')
 except:
     pass

--- a/tutorials/wamit/COER_hydrodynamic_modeling_comp/run.py
+++ b/tutorials/wamit/COER_hydrodynamic_modeling_comp/run.py
@@ -6,7 +6,7 @@ from bemio.io.output import write_hdf5
 wamit_data_f = read(out_file='wamit_data/coer_comp_f.out')
 
 # Calculate IRF and SS coefficients
-for i in xrange(wamit_data_f.body[0].num_bodies):
+for i in range(wamit_data_f.body[0].num_bodies):
  	wamit_data_f.body[i].calc_irf_radiation(t_end=20.0, n_t=1001, n_w=501)
 	wamit_data_f.body[i].calc_irf_excitation(t_end=20.0, n_t=1001, n_w=501)
 
@@ -19,7 +19,7 @@ write_hdf5(wamit_data_f,out_file='coer_comp_f.h5')
 wamit_data_f_scaled = read(out_file='wamit_data/coer_comp_f.out', scale=True)
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data_f_scaled.body[0].num_bodies):
+for i in range(wamit_data_f_scaled.body[0].num_bodies):
  	wamit_data_f_scaled.body[i].calc_irf_radiation(t_end=20.0, n_t=1001, n_w=1001)
 	wamit_data_f_scaled.body[i].calc_irf_excitation(t_end=20.0, n_t=1001, n_w=1001)
 

--- a/tutorials/wamit/COER_hydrodynamic_modeling_comp/run.py
+++ b/tutorials/wamit/COER_hydrodynamic_modeling_comp/run.py
@@ -7,7 +7,7 @@ wamit_data_f = read(out_file='wamit_data/coer_comp_f.out')
 
 # Calculate IRF and SS coefficients
 for i in range(wamit_data_f.body[0].num_bodies):
- 	wamit_data_f.body[i].calc_irf_radiation(t_end=20.0, n_t=1001, n_w=501)
+	wamit_data_f.body[i].calc_irf_radiation(t_end=20.0, n_t=1001, n_w=501)
 	wamit_data_f.body[i].calc_irf_excitation(t_end=20.0, n_t=1001, n_w=501)
 
 # Save the data in the hdf5 format.
@@ -20,7 +20,7 @@ wamit_data_f_scaled = read(out_file='wamit_data/coer_comp_f.out', scale=True)
 
 # Calculate IRF and plot using the wamit module
 for i in range(wamit_data_f_scaled.body[0].num_bodies):
- 	wamit_data_f_scaled.body[i].calc_irf_radiation(t_end=20.0, n_t=1001, n_w=1001)
+	wamit_data_f_scaled.body[i].calc_irf_radiation(t_end=20.0, n_t=1001, n_w=1001)
 	wamit_data_f_scaled.body[i].calc_irf_excitation(t_end=20.0, n_t=1001, n_w=1001)
 
 # Save the data in the hdf5 format.

--- a/tutorials/wamit/ecm_ellipsoid/run.py
+++ b/tutorials/wamit/ecm_ellipsoid/run.py
@@ -12,7 +12,7 @@ wamit_data = read(out_file='./ecm_ellipsoid.out')
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=100,n_t=201,n_w=201)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=50,n_t=101,n_w=101)

--- a/tutorials/wamit/ecm_ellipsoid/run.py
+++ b/tutorials/wamit/ecm_ellipsoid/run.py
@@ -13,7 +13,7 @@ wamit_data = read(out_file='./ecm_ellipsoid.out')
 
 # Calculate IRF and plot using the wamit module
 for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
- 	wamit_data.body[i].calc_irf_radiation(t_end=100,n_t=201,n_w=201)
+	wamit_data.body[i].calc_irf_radiation(t_end=100,n_t=201,n_w=201)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=50,n_t=101,n_w=101)
 

--- a/tutorials/wamit/oswec/run.py
+++ b/tutorials/wamit/oswec/run.py
@@ -8,7 +8,7 @@ wamit_data = read(out_file='wamit_data/oswec.out')
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=20, n_t=501, n_w=501, w_max=10.)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=30. , n_t=501, n_w=501)

--- a/tutorials/wamit/oswec/run.py
+++ b/tutorials/wamit/oswec/run.py
@@ -9,7 +9,7 @@ wamit_data = read(out_file='wamit_data/oswec.out')
 
 # Calculate IRF and plot using the wamit module
 for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
- 	wamit_data.body[i].calc_irf_radiation(t_end=20, n_t=501, n_w=501, w_max=10.)
+	wamit_data.body[i].calc_irf_radiation(t_end=20, n_t=501, n_w=501, w_max=10.)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=30. , n_t=501, n_w=501)
 

--- a/tutorials/wamit/rm3/run.py
+++ b/tutorials/wamit/rm3/run.py
@@ -11,7 +11,7 @@ wamit_data = read(out_file='wamit_data/rm3.out',scale=False)
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=20., n_t=1001, n_w=501)
 	#wamit_data.body[i].calc_ss_radiation()
 	wamit_data.body[i].calc_irf_excitation(t_end=100., n_t=1001, n_w=501, w_max=1.25)

--- a/tutorials/wamit/rm3/run.py
+++ b/tutorials/wamit/rm3/run.py
@@ -12,7 +12,7 @@ wamit_data = read(out_file='wamit_data/rm3.out',scale=False)
 
 # Calculate IRF and plot using the wamit module
 for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
- 	wamit_data.body[i].calc_irf_radiation(t_end=20., n_t=1001, n_w=501)
+	wamit_data.body[i].calc_irf_radiation(t_end=20., n_t=1001, n_w=501)
 	#wamit_data.body[i].calc_ss_radiation()
 	wamit_data.body[i].calc_irf_excitation(t_end=100., n_t=1001, n_w=501, w_max=1.25)
 

--- a/tutorials/wamit/sphere/run.py
+++ b/tutorials/wamit/sphere/run.py
@@ -12,7 +12,7 @@ wamit_data = read(out_file='./sphere.out')
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=100,n_t=201,n_w=201)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=50,n_t=101,n_w=101)

--- a/tutorials/wamit/sphere/run.py
+++ b/tutorials/wamit/sphere/run.py
@@ -13,7 +13,7 @@ wamit_data = read(out_file='./sphere.out')
 
 # Calculate IRF and plot using the wamit module
 for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
- 	wamit_data.body[i].calc_irf_radiation(t_end=100,n_t=201,n_w=201)
+	wamit_data.body[i].calc_irf_radiation(t_end=100,n_t=201,n_w=201)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=50,n_t=101,n_w=101)
 

--- a/tutorials/wamit/wec3/run.py
+++ b/tutorials/wamit/wec3/run.py
@@ -12,7 +12,7 @@ wamit_data = read(out_file='./wec3.out')
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=100., n_t=1001, n_w=501)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=100., n_t=1001, n_w=501)

--- a/tutorials/wamit/wec3/run.py
+++ b/tutorials/wamit/wec3/run.py
@@ -13,7 +13,7 @@ wamit_data = read(out_file='./wec3.out')
 
 # Calculate IRF and plot using the wamit module
 for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
- 	wamit_data.body[i].calc_irf_radiation(t_end=100., n_t=1001, n_w=501)
+	wamit_data.body[i].calc_irf_radiation(t_end=100., n_t=1001, n_w=501)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=100., n_t=1001, n_w=501)
 

--- a/tutorials/wamit/wec3_3Bodies/run.py
+++ b/tutorials/wamit/wec3_3Bodies/run.py
@@ -12,7 +12,7 @@ wamit_data = read(out_file='./wec3.out')
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=100., n_t=1001, n_w=1001)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=100., n_t=1001, n_w=1001)

--- a/tutorials/wamit/wec3_single_body/run.py
+++ b/tutorials/wamit/wec3_single_body/run.py
@@ -12,7 +12,7 @@ wamit_data = read(out_file='./wec3.out')
 
 
 # Calculate IRF and plot using the wamit module
-for i in xrange(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
+for i in range(wamit_data.body[0].num_bodies): #wamit_data.body[0].num_bodies
  	wamit_data.body[i].calc_irf_radiation(t_end=100., n_t=1001, n_w=501)
 	#wamit_data.body[i].calc_ss_radiation(max_order=5, r2_thresh=0.90)
 	wamit_data.body[i].calc_irf_excitation(t_end=100., n_t=1001, n_w=501)


### PR DESCRIPTION
I am working on a project with @ryancoe where we want to use Bemio, but we are using Python 3 as a base, while Bemio still requires Python 2. This addition allows Bemio to work with Python version >=3.3 while still being compatible with Python 2.

The majority of the additions were automated using the Python [`2to3`](https://docs.python.org/3/library/2to3.html) package and are rudimentary syntax changes (e.g. `print '...'` -> `print('...')`). There are also two minor corrections in [`data_structures/wave_excitation.py`](https://github.com/michaelcdevin/bemio/blob/941a43e8c900e84652aec89fd6478e7baf8eb42b/bemio/data_structures/wave_excitation.py#L77) and [`io/nemoh.py`](https://github.com/michaelcdevin/bemio/blob/941a43e8c900e84652aec89fd6478e7baf8eb42b/bemio/io/nemoh.py#L173) discovered while running the case tests.

`python install_test.py all` was successfully run for both Python 2.7 and 3.9, but let me know if any other compatibility issues are discovered.